### PR TITLE
Update bitpack_ext.c

### DIFF
--- a/ext/bitpack_ext.c
+++ b/ext/bitpack_ext.c
@@ -654,7 +654,7 @@ void Init_bitpack()
     bp_exceptions[BITPACK_ERR_VALUE_TOO_BIG] = rb_eArgError;
     bp_exceptions[BITPACK_ERR_RANGE_TOO_BIG] = rb_eRangeError;
     bp_exceptions[BITPACK_ERR_READ_PAST_END] = rb_eRangeError;
-    bp_exceptions[BITPACK_ERR_EMPTY]         = rb_eRangeError;
+    // bp_exceptions[BITPACK_ERR_EMPTY]         = rb_eRangeError;
 
     /* require the pure ruby methods */
     rb_require("lib/bitpack.rb");


### PR DESCRIPTION
On line 657 array 'bp_exceptions[6]' is accessed at index 6, which is out of bounds.

Found by https://github.com/danmar/cppcheck
